### PR TITLE
Add Echo Check GitHub Action

### DIFF
--- a/.github/workflows/echo-check.yml
+++ b/.github/workflows/echo-check.yml
@@ -1,0 +1,25 @@
+name: Echo Check
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  echo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call echo server and check response
+        run: |
+          # echo server reflects back query params under .request.query
+          response=$(curl -sf "https://echo.dev-porter.run/get?message=hello")
+          echo "Response: $response"
+
+          expected="hello"
+          actual=$(echo "$response" | jq -r '.request.query.message')
+
+          if [ "$actual" = "$expected" ]; then
+            echo "Match: args.message = '$actual'"
+          else
+            echo "Mismatch: expected '$expected', got '$actual'"
+            exit 1
+          fi


### PR DESCRIPTION
Adds a simple GitHub Action that calls the echo server and validates the response.

## What it does
1. Calls the echo server at `https://echo.dev-porter.run/get?message=hello`
2. Extracts the reflected query param at `.request.query.message` with `jq`
3. Passes if it equals `hello`, otherwise prints the mismatch and fails the job

Triggers on every `push` and manual `workflow_dispatch`. Verified the check logic end-to-end against a local instance of the echo server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)